### PR TITLE
Adding support for LoadBalancerIP field in ServiceSpec

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # MaaS Vault
 
 This is a forked version of HashiCorp's Vault Helm Chart. It is forked for business continuity (should the original be deleted) and to adhere to the MPL-2.0 license of public disclosure of source changes.
-This repository is used as a submodule in other repositories that install and setup Vault. No changes should be required in this repository.
+This repository is used as a submodule in other repositories that install and setup Vault.
 
 # Vault Helm Chart
 
@@ -41,3 +41,13 @@ then be installed directly:
 Please see the many options supported in the `values.yaml`
 file. These are also fully documented directly on the
 [Vault website](https://www.vaultproject.io/docs/platform/k8s/helm.html).
+
+## Customizations
+
+This Helm chart has been customized in the following ways:
+
+### Support LoadBalancerIP Field
+
+The Service spec in the **server-service.yaml** file now allows setting a
+specific IP address when the Service type is set to `LoadBalancer` and a
+**maas.lbAddress** value has been provided.

--- a/templates/server-service.yaml
+++ b/templates/server-service.yaml
@@ -27,6 +27,9 @@ spec:
   {{- if .Values.server.service.clusterIP }}
   clusterIP: {{ .Values.server.service.clusterIP }}
   {{- end }}
+  {{- if and (.Values.maas.lbAddress) (eq (.Values.server.service.type | toString) "LoadBalancer") }}
+  loadBalancerIP: {{ .Values.maas.lbAddress }}
+  {{- end }}
   # We want the servers to become available even if they're not ready
   # since this DNS is also used for join operations.
   publishNotReadyAddresses: true

--- a/values.yaml
+++ b/values.yaml
@@ -210,13 +210,17 @@ server:
     # load balancer.
     # clusterIP: None
 
-    # Configures the service type for the main Vault service.  Can be ClusterIP
-    # or NodePort.
+    # Configures the service type for the main Vault service.  Can be ClusterIP,
+    # NodePort, or LoadBalancer.
     #type: ClusterIP
 
     # If type is set to "NodePort", a specific nodePort value can be configured,
     # will be random if left blank.
     #nodePort: 30000
+
+    # If type is set to "LoadBalancer", a specific IP address can be attached
+    # to the load balancer, will be random if left blank.
+    #loadBalancerIP: 
 
     # Port on which Vault server is listening
     port: 8200


### PR DESCRIPTION
This PR adds the ability to set a value for the **loadBalancerIP** field in the **ServiceSpec**.  With this change, that field will be included in the spec if the **type** field is set to `LoadBalancer` and a **maas.lbAddress** value is provided.  The field will be set to the **maas.lbAddress** value.