### PR TITLE
DATAGO-13861: Adding support for logrotate

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -88,6 +88,11 @@ extra volumes the user may have specified (such as a secret with TLS).
           configMap:
             name: {{ template "vault.fullname" . }}-config
   {{ end }}
+  {{- if .Values.server.logrotate }}
+        - name: {{ template "vault.fullname" . }}-logrotate-configs-vol
+          configMap:
+            name: {{ template "vault.fullname" . }}-logrotate-config
+  {{- end}}
   {{- range .Values.server.extraVolumes }}
         - name: userconfig-{{ .name }}
           {{ .type }}:
@@ -196,6 +201,7 @@ storage might be desired by the user.
           {{- end }}
       {{ end }}
   {{ end }}
+
 {{- end -}}
 
 {{/*

--- a/templates/logrotate-config-configmap.yaml
+++ b/templates/logrotate-config-configmap.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.server.logrotate}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "vault.fullname" . }}-logrotate-config
+  namespace: {{ .Release.Namespace }}
+data:
+  logrotate.conf: |
+    /vault/audit/audit.log {
+        rotate 1
+        copytruncate
+        size 5M
+        missingok
+        compress
+        postrotate
+            pkill -HUP -f "vault server"
+            echo  "`date`: Audit log rotated  -  SIGHUP exit code is $?" > /vault/audit/last-rotate-status
+        endscript
+    }
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -160,10 +160,6 @@ server:
   # to Vault in the path `/vault/userconfig/<name>/`. The value below is
   # an array of objects, examples are shown below.
   extraVolumes: []
-    # - type: secret (or "configMap")
-    #   name: my-secret
-    #   path: null # default is `/vault/userconfig`
-
   # Affinity Settings
   # Commenting out or setting as empty the affinity variable, will allow
   # deployment to single node services such as Minikube
@@ -345,6 +341,8 @@ server:
   # Definition of the serviceAccount used to run Vault.
   serviceAccount:
     annotations: {}
+  # A boolean flag to setup logrotate as a side car continer
+  logrotate: null
 
 # Vault UI
 ui:


### PR DESCRIPTION
Extending vault-helm repo so it can support adding a log rotate config map. 