### PR TITLE
Datago 27001/upgrade vault to 1.6.7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,14 +6,14 @@ jobs:
   bats-unit-test:
     docker:
       # This image is built from test/docker/Test.dockerfile
-      - image: hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
     steps:
       - checkout
       - run: bats ./test/unit -t
   acceptance:
     docker:
       # This image is build from test/docker/Test.dockerfile
-      - image: hashicorpdev/vault-helm-test:0.1.0
+      - image: docker.mirror.hashicorp.services/hashicorpdev/vault-helm-test:0.1.0
 
     steps:
       - checkout
@@ -35,7 +35,7 @@ jobs:
           when: always
   update-helm-charts-index:
     docker:
-      - image: circleci/golang:latest
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.15.3
     steps:
       - checkout
       - run:

--- a/.github/workflows/jira.yaml
+++ b/.github/workflows/jira.yaml
@@ -5,7 +5,6 @@ on:
     types: [opened, closed, reopened]
   issue_comment: # Also triggers when commenting on a PR from the conversation view
     types: [created]
-  workflow_dispatch:
 
 name: Jira Sync
 
@@ -36,9 +35,9 @@ jobs:
         JIRA_USER_EMAIL: ${{ secrets.JIRA_SYNC_USER_EMAIL }}
         JIRA_API_TOKEN: ${{ secrets.JIRA_SYNC_API_TOKEN }}
 
-    - name: Set ticket type
-      if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
-      id: set-ticket-type
+    - name: Preprocess
+      if: github.event.action == 'opened' || github.event.action == 'created'
+      id: preprocess
       run: |
         if [[ "${{ github.event_name }}" == "pull_request_target" ]]; then
           echo "::set-output name=type::PR"
@@ -48,15 +47,15 @@ jobs:
 
     - name: Create ticket
       if: github.event.action == 'opened' && !steps.vault-team-role.outputs.role
-      uses: tomhjp/gh-action-jira-create@v0.1.3
+      uses: tomhjp/gh-action-jira-create@v0.2.0
       with:
         project: VAULT
         issuetype: "GH Issue"
-        summary: "${{ github.event.repository.name }} [${{ steps.set-ticket-type.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
+        summary: "${{ github.event.repository.name }} [${{ steps.preprocess.outputs.type }} #${{ github.event.issue.number || github.event.pull_request.number }}]: ${{ github.event.issue.title || github.event.pull_request.title }}"
         description: "${{ github.event.issue.body || github.event.pull_request.body }}\n\n_Created from GitHub Action for ${{ github.event.issue.html_url || github.event.pull_request.html_url }} from ${{ github.actor }}_"
         # customfield_10089 is Issue Link custom field
         # customfield_10091 is team custom field
-        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["ecosystem"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
+        extraFields: '{"fixVersions": [{"name": "TBD"}], "customfield_10091": ["ecosystem", "runtime"], "customfield_10089": "${{ github.event.issue.html_url || github.event.pull_request.html_url }}"}'
 
     - name: Search
       if: github.event.action != 'opened'
@@ -68,7 +67,7 @@ jobs:
 
     - name: Sync comment
       if: github.event.action == 'created' && steps.search.outputs.issue
-      uses: tomhjp/gh-action-jira-comment@v0.1.0
+      uses: tomhjp/gh-action-jira-comment@v0.2.0
       with:
         issue: ${{ steps.search.outputs.issue }}
         comment: "${{ github.actor }} ${{ github.event.review.state || 'commented' }}:\n\n${{ github.event.comment.body || github.event.review.body }}\n\n${{ github.event.comment.html_url || github.event.review.html_url }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Improvements:
 * Dev mode root token is now configurable with `server.dev.devRootToken` [GH-415](https://github.com/hashicorp/vault-helm/pull/415)
 * ClusterRoleBinding updated to `v1` [GH-395](https://github.com/hashicorp/vault-helm/pull/395)
 * MutatingWebhook updated to `v1` [GH-408](https://github.com/hashicorp/vault-helm/pull/408)
+* Injector service now supports `injector.service.annotations`  [425](https://github.com/hashicorp/vault-helm/pull/425)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Improvements:
 * Injector service now supports `injector.service.annotations` [425](https://github.com/hashicorp/vault-helm/pull/425)
 * Injector now supports `injector.extraLabels` [428](https://github.com/hashicorp/vault-helm/pull/428)
 * Added `allowPrivilegeEscalation: false` to Vault and Injector containers [429](https://github.com/hashicorp/vault-helm/pull/429)
+* Network Policy now supports `server.networkPolicy.egress` [389](https://github.com/hashicorp/vault-helm/pull/389)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Improvements:
 * Dev mode now supports `server.extraArgs` [GH-421](https://github.com/hashicorp/vault-helm/pull/421)
+* Dev mode root token is now configurable with `server.dev.devRootToken` [GH-415](https://github.com/hashicorp/vault-helm/pull/415)
 * ClusterRoleBinding updated to `v1` [GH-395](https://github.com/hashicorp/vault-helm/pull/395)
 
 ## 0.8.0 (October 20th, 2020)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Improvements:
 * Injector now supports `injector.extraLabels` [428](https://github.com/hashicorp/vault-helm/pull/428)
 * Added `allowPrivilegeEscalation: false` to Vault and Injector containers [429](https://github.com/hashicorp/vault-helm/pull/429)
 * Network Policy now supports `server.networkPolicy.egress` [389](https://github.com/hashicorp/vault-helm/pull/389)
+* Injector now supports multiple replicas with leader elections for setting up auto TLS [GH-436](https://github.com/hashicorp/vault-helm/pull/436)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ Improvements:
 * Dev mode root token is now configurable with `server.dev.devRootToken` [GH-415](https://github.com/hashicorp/vault-helm/pull/415)
 * ClusterRoleBinding updated to `v1` [GH-395](https://github.com/hashicorp/vault-helm/pull/395)
 * MutatingWebhook updated to `v1` [GH-408](https://github.com/hashicorp/vault-helm/pull/408)
-* Injector service now supports `injector.service.annotations`  [425](https://github.com/hashicorp/vault-helm/pull/425)
+* Injector service now supports `injector.service.annotations` [425](https://github.com/hashicorp/vault-helm/pull/425)
+* Injector now supports `injector.extraLabels` [428](https://github.com/hashicorp/vault-helm/pull/428)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## Unreleased
 
-Improvements:
-* Set VAULT_DEV_LISTEN_ADDRESS in dev mode [GH-446](https://github.com/hashicorp/vault-helm/pull/446)
-
 Bugs:
 * Injector: fix labels for default anti-affinity rule [GH-441](https://github.com/hashicorp/vault-helm/pull/441), [GH-442](https://github.com/hashicorp/vault-helm/pull/442)
+* Set VAULT_DEV_LISTEN_ADDRESS in dev mode [GH-446](https://github.com/hashicorp/vault-helm/pull/446)
 
 ## 0.9.0 (January 5th, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 Bugs:
-* Injector: fix component label for default anti-affinity rule [GH-441](https://github.com/hashicorp/vault-helm/pull/441)
+* Injector: fix labels for default anti-affinity rule [GH-441](https://github.com/hashicorp/vault-helm/pull/441), [GH-442](https://github.com/hashicorp/vault-helm/pull/442)
 
 ## 0.9.0 (January 5th, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Improvements:
+* Set VAULT_DEV_LISTEN_ADDRESS in dev mode [GH-446](https://github.com/hashicorp/vault-helm/pull/446)
+
 Bugs:
 * Injector: fix labels for default anti-affinity rule [GH-441](https://github.com/hashicorp/vault-helm/pull/441), [GH-442](https://github.com/hashicorp/vault-helm/pull/442)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Bugs:
+* Injector: fix component label for default anti-affinity rule [GH-441](https://github.com/hashicorp/vault-helm/pull/441)
+
 ## 0.9.0 (January 5th, 2021)
 
 Features:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Improvements:
 * MutatingWebhook updated to `v1` [GH-408](https://github.com/hashicorp/vault-helm/pull/408)
 * Injector service now supports `injector.service.annotations` [425](https://github.com/hashicorp/vault-helm/pull/425)
 * Injector now supports `injector.extraLabels` [428](https://github.com/hashicorp/vault-helm/pull/428)
+* Added `allowPrivilegeEscalation: false` to Vault and Injector containers [429](https://github.com/hashicorp/vault-helm/pull/429)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Improvements:
 * Dev mode now supports `server.extraArgs` [GH-421](https://github.com/hashicorp/vault-helm/pull/421)
 * Dev mode root token is now configurable with `server.dev.devRootToken` [GH-415](https://github.com/hashicorp/vault-helm/pull/415)
 * ClusterRoleBinding updated to `v1` [GH-395](https://github.com/hashicorp/vault-helm/pull/395)
+* MutatingWebhook updated to `v1` [GH-408](https://github.com/hashicorp/vault-helm/pull/408)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.9.1 (February 2nd, 2021)
+
 Bugs:
 * Injector: fix labels for default anti-affinity rule [GH-441](https://github.com/hashicorp/vault-helm/pull/441), [GH-442](https://github.com/hashicorp/vault-helm/pull/442)
 * Set VAULT_DEV_LISTEN_ADDRESS in dev mode [GH-446](https://github.com/hashicorp/vault-helm/pull/446)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+Features:
+* Injector now supports configurable number of replicas [GH-436](https://github.com/hashicorp/vault-helm/pull/436)
+* Injector now supports auto TLS for multiple replicas using leader elections [GH-436](https://github.com/hashicorp/vault-helm/pull/436)
+
 Improvements:
 * Dev mode now supports `server.extraArgs` [GH-421](https://github.com/hashicorp/vault-helm/pull/421)
 * Dev mode root token is now configurable with `server.dev.devRootToken` [GH-415](https://github.com/hashicorp/vault-helm/pull/415)
@@ -9,7 +13,6 @@ Improvements:
 * Injector now supports `injector.extraLabels` [428](https://github.com/hashicorp/vault-helm/pull/428)
 * Added `allowPrivilegeEscalation: false` to Vault and Injector containers [429](https://github.com/hashicorp/vault-helm/pull/429)
 * Network Policy now supports `server.networkPolicy.egress` [389](https://github.com/hashicorp/vault-helm/pull/389)
-* Injector now supports multiple replicas with leader elections for setting up auto TLS [GH-436](https://github.com/hashicorp/vault-helm/pull/436)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+## 0.9.0 (January 5th, 2021)
+
 Features:
 * Injector now supports configurable number of replicas [GH-436](https://github.com/hashicorp/vault-helm/pull/436)
 * Injector now supports auto TLS for multiple replicas using leader elections [GH-436](https://github.com/hashicorp/vault-helm/pull/436)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Unreleased
 
+Improvements:
+* Dev mode now supports `server.extraArgs` [GH-421](https://github.com/hashicorp/vault-helm/pull/421)
+
 ## 0.8.0 (October 20th, 2020)
 
 Improvements:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Improvements:
 * Dev mode now supports `server.extraArgs` [GH-421](https://github.com/hashicorp/vault-helm/pull/421)
+* ClusterRoleBinding updated to `v1` [GH-395](https://github.com/hashicorp/vault-helm/pull/395)
 
 ## 0.8.0 (October 20th, 2020)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
-version: 0.8.0
-appVersion: 1.5.4
+version: 0.9.0
+appVersion: 1.6.1
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: vault
-version: 0.9.0
-appVersion: 1.6.1
+version: 0.9.1
+appVersion: 1.6.2
 description: Official HashiCorp Vault Chart
 home: https://www.vaultproject.io
 icon: https://github.com/hashicorp/vault/raw/f22d202cde2018f9455dec755118a9b84586e082/Vault_PrimaryLogo_Black.png

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -294,6 +294,21 @@ Sets extra injector pod annotations
 {{- end -}}
 
 {{/*
+Sets extra injector service annotations
+*/}}
+{{- define "injector.service.annotations" -}}
+  {{- if .Values.injector.service.annotations }}
+  annotations:
+    {{- $tp := typeOf .Values.injector.service.annotations }}
+    {{- if eq $tp "string" }}
+      {{- tpl .Values.injector.service.annotations . | nindent 4 }}
+    {{- else }}
+      {{- toYaml .Values.injector.service.annotations | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end -}}
+
+{{/*
 Sets extra ui service annotations
 */}}
 {{- define "vault.ui.annotations" -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -131,7 +131,7 @@ Set's additional environment variables based on the mode.
 {{- define "vault.envs" -}}
   {{ if eq .mode "dev" }}
             - name: VAULT_DEV_ROOT_TOKEN_ID
-              value: "root"
+              value: {{ .Values.server.dev.devRootToken }}
   {{ end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -132,6 +132,8 @@ Set's additional environment variables based on the mode.
   {{ if eq .mode "dev" }}
             - name: VAULT_DEV_ROOT_TOKEN_ID
               value: {{ .Values.server.dev.devRootToken }}
+            - name: VAULT_DEV_LISTEN_ADDRESS
+              value: "[::]:8200"
   {{ end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -104,18 +104,6 @@ extra volumes the user may have specified (such as a secret with TLS).
 {{- end -}}
 
 {{/*
-Set's a command to override the entrypoint defined in the image
-so we can make the user experience nicer.  This works in with
-"vault.args" to specify what commands /bin/sh should run.
-*/}}
-{{- define "vault.command" -}}
-  {{ if or (eq .mode "standalone") (eq .mode "ha") }}
-          - "/bin/sh"
-          - "-ec"
-  {{ end }}
-{{- end -}}
-
-{{/*
 Set's the args for custom command to render the Vault configuration
 file with IP addresses to make the out of box experience easier
 for users looking to use this chart with Consul Helm.
@@ -131,6 +119,9 @@ for users looking to use this chart with Consul Helm.
             [ -n "${TRANSIT_ADDR}" ] && sed -Ei "s|TRANSIT_ADDR|${TRANSIT_ADDR?}|g" /tmp/storageconfig.hcl;
             [ -n "${RAFT_ADDR}" ] && sed -Ei "s|RAFT_ADDR|${RAFT_ADDR?}|g" /tmp/storageconfig.hcl;
             /usr/local/bin/docker-entrypoint.sh vault server -config=/tmp/storageconfig.hcl {{ .Values.server.extraArgs }}
+   {{ else if eq .mode "dev" }}
+          - |
+            /usr/local/bin/docker-entrypoint.sh vault server -dev {{ .Values.server.extraArgs }}
   {{ end }}
 {{- end -}}
 

--- a/templates/injector-certs-secret.yaml
+++ b/templates/injector-certs-secret.yaml
@@ -1,0 +1,10 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: vault-injector-certs
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -23,6 +23,9 @@ spec:
         app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
         app.kubernetes.io/instance: {{ .Release.Name }}
         component: webhook
+        {{- if  .Values.injector.extraLabels -}}
+          {{- toYaml .Values.injector.extraLabels | nindent 8 -}}
+        {{- end -}}
       {{ template "injector.annotations" . }}
     spec:
       {{ template "injector.affinity" . }}

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -46,6 +46,10 @@ spec:
           {{ template "injector.resources" . }}
           image: "{{ .Values.injector.image.repository }}:{{ .Values.injector.image.tag }}"
           imagePullPolicy: "{{ .Values.injector.image.pullPolicy }}"
+          {{- if not .Values.global.openshift }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          {{- end }}
           env:
             - name: AGENT_INJECT_LISTEN
               value: ":8080"

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -106,7 +106,7 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 1
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -116,7 +116,7 @@ spec:
               port: 8080
               scheme: HTTPS
             failureThreshold: 2
-            initialDelaySeconds: 2
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -134,7 +134,7 @@ spec:
               port: 4040
               scheme: HTTP
             failureThreshold: 2
-            initialDelaySeconds: 1
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
@@ -144,7 +144,7 @@ spec:
               port: 4040
               scheme: HTTP
             failureThreshold: 2
-            initialDelaySeconds: 2
+            initialDelaySeconds: 5
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5

--- a/templates/injector-deployment.yaml
+++ b/templates/injector-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     component: webhook
 spec:
-  replicas: 1
+  replicas: {{ .Values.injector.replicas }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
@@ -88,6 +88,14 @@ spec:
             - name: AGENT_INJECT_TELEMETRY_PATH
               value: "/metrics"
             {{- end }}
+            {{- if and (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+            - name: AGENT_INJECT_USE_LEADER_ELECTOR
+              value: "true"
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            {{- end }}
             {{- include "vault.extraEnvironmentVars" .Values.injector | nindent 12 }}
           args:
             - agent-inject
@@ -112,6 +120,35 @@ spec:
             periodSeconds: 2
             successThreshold: 1
             timeoutSeconds: 5
+        {{- if and (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+        - name: leader-elector
+          image: {{ .Values.injector.leaderElector.image.repository }}:{{ .Values.injector.leaderElector.image.tag }}
+          args:
+            - --election={{ template "vault.fullname" . }}-agent-injector-leader
+            - --election-namespace={{ .Release.Namespace }}
+            - --http=0.0.0.0:4040
+            - --ttl={{ .Values.injector.leaderElector.ttl }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: 4040
+              scheme: HTTP
+            failureThreshold: 2
+            initialDelaySeconds: 1
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 4040
+              scheme: HTTP
+            failureThreshold: 2
+            initialDelaySeconds: 2
+            periodSeconds: 2
+            successThreshold: 1
+            timeoutSeconds: 5
+        {{- end }}
 {{- if .Values.injector.certs.secretName }}
           volumeMounts:
             - name: webhook-certs

--- a/templates/injector-leader-endpoint.yaml
+++ b/templates/injector-leader-endpoint.yaml
@@ -1,0 +1,12 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+# This is created here so it can be cleaned up easily, since if
+# the endpoint is left around the leader won't expire for about a minute.
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector-leader
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}

--- a/templates/injector-mutating-webhook.yaml
+++ b/templates/injector-mutating-webhook.yaml
@@ -1,5 +1,9 @@
 {{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if .Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1" }}
+apiVersion: admissionregistration.k8s.io/v1
+{{- else }}
 apiVersion: admissionregistration.k8s.io/v1beta1
+{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ template "vault.fullname" . }}-agent-injector-cfg
@@ -9,6 +13,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
 webhooks:
   - name: vault.hashicorp.com
+    sideEffects: None
+    admissionReviewVersions:
+    - "v1beta1"
+    - "v1"
     clientConfig:
       service:
         name: {{ template "vault.fullname" . }}-agent-injector-svc

--- a/templates/injector-role.yaml
+++ b/templates/injector-role.yaml
@@ -1,0 +1,19 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-role
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+rules:
+  - apiGroups: [""]
+    resources: ["endpoints", "secrets"]
+    verbs:
+      - "create"
+      - "get"
+      - "watch"
+      - "list"
+      - "update"
+{{- end }}

--- a/templates/injector-rolebinding.yaml
+++ b/templates/injector-rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if and (eq (.Values.injector.enabled | toString) "true" ) (eq (.Values.global.enabled | toString) "true") (eq (.Values.injector.leaderElector.enabled | toString) "true") (gt (.Values.injector.replicas | int) 1) }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-binding
+  labels:
+    app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "vault.fullname" . }}-agent-injector-leader-elector-role
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "vault.fullname" . }}-agent-injector
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/templates/injector-service.yaml
+++ b/templates/injector-service.yaml
@@ -8,6 +8,7 @@ metadata:
     app.kubernetes.io/name: {{ include "vault.name" . }}-agent-injector
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{ template "injector.service.annotations" . }}
 spec:
   ports:
   - port: 443

--- a/templates/server-clusterrolebinding.yaml
+++ b/templates/server-clusterrolebinding.yaml
@@ -1,6 +1,10 @@
 {{ template "vault.mode" . }}
 {{- if and (ne .mode "") (and (eq (.Values.global.enabled | toString) "true") (eq (.Values.server.authDelegator.enabled | toString) "true")) }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: ClusterRoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-server-binding

--- a/templates/server-discovery-rolebinding.yaml
+++ b/templates/server-discovery-rolebinding.yaml
@@ -1,7 +1,11 @@
 {{ template "vault.mode" . }}
 {{- if ne .mode "external" }}
 {{- if and (eq .mode "ha" ) (eq (.Values.global.enabled | toString) "true") }}
+{{- if .Capabilities.APIVersions.Has "rbac.authorization.k8s.io/v1" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+{{- else }}
 apiVersion: rbac.authorization.k8s.io/v1beta1
+{{- end }}
 kind: RoleBinding
 metadata:
   name: {{ template "vault.fullname" . }}-discovery-rolebinding

--- a/templates/server-network-policy.yaml
+++ b/templates/server-network-policy.yaml
@@ -19,4 +19,8 @@ spec:
         protocol: TCP
       - port: 8201
         protocol: TCP
+  {{- if .Values.server.networkPolicy.egress }}
+  egress:
+  {{- toYaml .Values.server.networkPolicy.egress | nindent 4 }}
+  {{ end }}
 {{ end }}

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -66,7 +66,9 @@ spec:
           {{ template "vault.resources" . }}
           image: {{ .Values.server.image.repository }}:{{ .Values.server.image.tag | default "latest" }}
           imagePullPolicy: {{ .Values.server.image.pullPolicy }}
-          command: {{ template "vault.command" . }}
+          command:
+          - "/bin/sh"
+          - "-ec"
           args: {{ template "vault.args" . }}
           env:
             - name: HOST_IP

--- a/templates/server-statefulset.yaml
+++ b/templates/server-statefulset.yaml
@@ -70,6 +70,10 @@ spec:
           - "/bin/sh"
           - "-ec"
           args: {{ template "vault.args" . }}
+          {{- if not .Values.global.openshift }}
+          securityContext:
+            allowPrivilegeEscalation: false
+          {{- end }}
           env:
             - name: HOST_IP
               valueFrom:

--- a/test/acceptance/injector-leader-elector.bats
+++ b/test/acceptance/injector-leader-elector.bats
@@ -11,7 +11,7 @@ load _helpers
 
   helm install "$(name_prefix)" \
     --set="injector.replicas=3" .
-  kubectl wait --for condition=Ready pod -l app.kubernetes.io/name=vault-agent-injector
+  kubectl wait --for condition=Ready pod -l app.kubernetes.io/name=vault-agent-injector --timeout=5m
 
   pods=($(kubectl get pods -l app.kubernetes.io/name=vault-agent-injector -o json | jq -r '.items[] | .metadata.name'))
   [ "${#pods[@]}" == 3 ]

--- a/test/acceptance/injector-leader-elector.bats
+++ b/test/acceptance/injector-leader-elector.bats
@@ -1,0 +1,46 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+@test "injector: testing leader elector" {
+  cd `chart_dir`
+  
+  kubectl delete namespace acceptance --ignore-not-found=true
+  kubectl create namespace acceptance
+  kubectl config set-context --current --namespace=acceptance
+
+  helm install "$(name_prefix)" \
+    --set="injector.replicas=3" .
+  kubectl wait --for condition=Ready pod -l app.kubernetes.io/name=vault-agent-injector
+
+  pods=($(kubectl get pods -l app.kubernetes.io/name=vault-agent-injector -o json | jq -r '.items[] | .metadata.name'))
+  [ "${#pods[@]}" == 3 ]
+
+  leader="$(echo "$(kubectl exec ${pods[0]} -c sidecar-injector -- wget --quiet --output-document - localhost:4040)" | jq -r .name)"
+  # Check the leader name is valid - i.e. one of the 3 pods
+  [[ " ${pods[@]} " =~ " ${leader} " ]]
+
+  # Check every pod agrees on who the leader is
+  for pod in "${pods[@]}"
+  do
+    pod_leader="$(echo "$(kubectl exec $pod -c sidecar-injector -- wget --quiet --output-document - localhost:4040)" | jq -r .name)"
+    [ "${pod_leader}" == "${leader}" ]
+  done
+}
+
+setup() {
+  kubectl delete namespace acceptance --ignore-not-found=true
+  kubectl create namespace acceptance
+  kubectl config set-context --current --namespace=acceptance
+}
+
+# Clean up
+teardown() {
+  if [[ ${CLEANUP:-true} == "true" ]]
+  then
+      echo "helm/pvc teardown"
+      helm delete vault
+      kubectl delete --all pvc
+      kubectl delete namespace acceptance
+  fi
+}

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.4_ent' \
+    --set='server.image.tag=1.6.1_ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.4_ent' \
+    --set='server.image.tag=1.6.1_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/test/acceptance/server-ha-enterprise-dr.bats
+++ b/test/acceptance/server-ha-enterprise-dr.bats
@@ -7,7 +7,7 @@ load _helpers
 
   helm install "$(name_prefix)-east" \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.6.1_ent' \
+    --set='server.image.tag=1.6.2_ent' \
     --set='injector.enabled=false' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.6.1_ent' \
+    --set='server.image.tag=1.6.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.6.1_ent' \
+    --set='server.image.tag=1.6.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-east-0"
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.6.1_ent' \
+    --set='server.image.tag=1.6.2_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/test/acceptance/server-ha-enterprise-perf.bats
+++ b/test/acceptance/server-ha-enterprise-perf.bats
@@ -8,7 +8,7 @@ load _helpers
   helm install "$(name_prefix)-east" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.4_ent' \
+    --set='server.image.tag=1.6.1_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-east-0"
@@ -76,7 +76,7 @@ load _helpers
   helm install "$(name_prefix)-west" \
     --set='injector.enabled=false' \
     --set='server.image.repository=hashicorp/vault-enterprise' \
-    --set='server.image.tag=1.5.4_ent' \
+    --set='server.image.tag=1.6.1_ent' \
     --set='server.ha.enabled=true' \
     --set='server.ha.raft.enabled=true' .
   wait_for_running "$(name_prefix)-west-0"

--- a/test/acceptance/server-ha.bats
+++ b/test/acceptance/server-ha.bats
@@ -90,7 +90,7 @@ setup() {
   kubectl config set-context --current --namespace=acceptance
 
   helm install consul \
-    https://github.com/hashicorp/consul-helm/archive/v0.16.2.tar.gz \
+    https://github.com/hashicorp/consul-helm/archive/v0.28.0.tar.gz \
     --set 'ui.enabled=false' \
 
   wait_for_running_consul

--- a/test/docker/Test.dockerfile
+++ b/test/docker/Test.dockerfile
@@ -6,7 +6,7 @@
 # a script to configure kubectl, potentially install Helm, and run the tests
 # manually. This image only has the dependencies pre-installed.
 
-FROM alpine:latest
+FROM docker.mirror.hashicorp.services/alpine:latest
 WORKDIR /root
 
 ENV BATS_VERSION "1.1.0"

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -531,3 +531,15 @@ load _helpers
       yq '.spec.template.spec.securityContext.runAsGroup | length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+#--------------------------------------------------------------------
+# extra labels
+
+@test "injector/deployment: specify extraLabels" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set 'injector.extraLabels.foo=bar' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.metadata.labels.foo' | tee /dev/stderr)
+  [ "${actual}" = "bar" ]
+}

--- a/test/unit/injector-deployment.bats
+++ b/test/unit/injector-deployment.bats
@@ -425,13 +425,13 @@ load _helpers
 #--------------------------------------------------------------------
 # affinity
 
-@test "injector/deployment: affinity not set by default" {
+@test "injector/deployment: affinity set by default" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-deployment.yaml  \
       . | tee /dev/stderr |
       yq '.spec.template.spec | .affinity? == null' | tee /dev/stderr)
-  [ "${actual}" = "true" ]
+  [ "${actual}" = "false" ]
 }
 
 @test "injector/deployment: affinity can be set" {

--- a/test/unit/injector-leader-elector.bats
+++ b/test/unit/injector-leader-elector.bats
@@ -1,0 +1,264 @@
+#!/usr/bin/env bats
+
+load _helpers
+
+#--------------------------------------------------------------------
+# Deployment
+
+@test "injector/deployment: leader elector replica count" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      . | tee /dev/stderr |
+      yq '.spec.replicas' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "injector/deployment: leader elector - sidecar is created only when enabled" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.leaderElector.enabled=false" \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers | length' | tee /dev/stderr)
+  [ "${actual}" = "1" ]
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      . | tee /dev/stderr |
+      yq '.spec.template.spec.containers | length' | tee /dev/stderr)
+  [ "${actual}" = "2" ]
+}
+
+@test "injector/deployment: leader elector image name is configurable" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.leaderElector.image.repository=SomeOtherImage" \
+      --set "injector.leaderElector.image.tag=SomeOtherTag" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].image' | tee /dev/stderr)
+  [ "${actual}" = "SomeOtherImage:SomeOtherTag" ]
+}
+
+@test "injector/deployment: leader elector configuration for sidecar-injector" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "AGENT_INJECT_USE_LEADER_ELECTOR") | .value' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "AGENT_INJECT_USE_LEADER_ELECTOR") | .value' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "NAMESPACE") | .valueFrom.fieldRef.fieldPath' | tee /dev/stderr)
+  [ "${actual}" = "" ]
+
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env[] | select(.name == "NAMESPACE") | .valueFrom.fieldRef.fieldPath' | tee /dev/stderr)
+  [ "${actual}" = "metadata.namespace" ]
+}
+
+@test "injector/deployment: leader elector TTL is configurable" {
+  cd `chart_dir`
+  # Default value 60s
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].args[3]' | tee /dev/stderr)
+  [ "${actual}" = "--ttl=60s" ]
+
+  # Configured to 30s
+  local actual=$(helm template \
+      --show-only templates/injector-deployment.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.leaderElector.ttl=30s" \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[1].args[3]' | tee /dev/stderr)
+  [ "${actual}" = "--ttl=30s" ]
+}
+
+#--------------------------------------------------------------------
+# Resource creation
+
+@test "injector/certs-secret: created/skipped as appropriate" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      --set "injector.replicas=2" \
+      --set "global.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.leaderElector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-certs-secret.yaml \
+      --set "injector.replicas=2" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "injector/leader-endpoint: created/skipped as appropriate" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-leader-endpoint.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-leader-endpoint.yaml \
+      --set "injector.replicas=2" \
+      --set "global.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-leader-endpoint.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-leader-endpoint.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.leaderElector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-leader-endpoint.yaml \
+      --set "injector.replicas=2" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "injector/role: created/skipped as appropriate" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      --set "injector.replicas=2" \
+      --set "global.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.leaderElector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-role.yaml \
+      --set "injector.replicas=2" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}
+
+@test "injector/rolebinding: created/skipped as appropriate" {
+  cd `chart_dir`
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      --set "injector.replicas=2" \
+      --set "global.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      --set "injector.replicas=2" \
+      --set "injector.leaderElector.enabled=false" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "false" ]
+
+  local actual=$( (helm template \
+      --show-only templates/injector-rolebinding.yaml \
+      --set "injector.replicas=2" \
+      . || echo "---") | tee /dev/stderr |
+      yq 'length > 0' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/injector-mutating-webhook.bats
+++ b/test/unit/injector-mutating-webhook.bats
@@ -76,7 +76,7 @@ load _helpers
   [ "${actual}" = "true" ]
 }
 
-@test "injector/MutatingWebhookConfiguration: failurePolicy empty by default" {
+@test "injector/MutatingWebhookConfiguration: failurePolicy 'Ignore' by default" {
   cd `chart_dir`
   local actual=$(helm template \
       --show-only templates/injector-mutating-webhook.yaml  \
@@ -84,7 +84,7 @@ load _helpers
       --namespace foo \
       . | tee /dev/stderr |
       yq '.webhooks[0].failurePolicy' | tee /dev/stderr)
-  [ "${actual}" = "null" ]
+  [ "${actual}" = "\"Ignore\"" ]
 }
 
 @test "injector/MutatingWebhookConfiguration: can set failurePolicy" {

--- a/test/unit/injector-service.bats
+++ b/test/unit/injector-service.bats
@@ -35,3 +35,13 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "false" ]
 }
+
+@test "injector/Service: generic annotations" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/injector-service.yaml \
+      --set 'injector.service.annotations=vaultIsAwesome: true' \
+      . | tee /dev/stderr |
+      yq -r '.metadata.annotations["vaultIsAwesome"]' | tee /dev/stderr)
+  [ "${actual}" = "true" ]
+}

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -236,6 +236,44 @@ load _helpers
 }
 
 #--------------------------------------------------------------------
+# devRootToken
+
+@test "server/dev-StatefulSet: set default devRootToken" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dev.enabled=true' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[11].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].value' | tee /dev/stderr)
+  [ "${actual}" = "root" ]
+}
+
+@test "server/dev-StatefulSet: set custom devRootToken" {
+  cd `chart_dir`
+  local object=$(helm template \
+      --show-only templates/server-statefulset.yaml  \
+      --set 'server.dev.enabled=true' \
+      --set 'server.dev.devRootToken=customtoken' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[11].name' | tee /dev/stderr)
+  [ "${actual}" = "VAULT_DEV_ROOT_TOKEN_ID" ]
+
+  local actual=$(echo $object |
+      yq -r '.[11].value' | tee /dev/stderr)
+  [ "${actual}" = "customtoken" ]
+}
+
+#--------------------------------------------------------------------
 # extraEnvironmentVars
 
 @test "server/dev-StatefulSet: set extraEnvironmentVars" {
@@ -249,7 +287,7 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
 
   local actual=$(echo $object |
-    yq -r '.[12].name' | tee /dev/stderr)
+      yq -r '.[12].name' | tee /dev/stderr)
   [ "${actual}" = "FOO" ]
 
   local actual=$(echo $object |

--- a/test/unit/server-dev-statefulset.bats
+++ b/test/unit/server-dev-statefulset.bats
@@ -403,3 +403,14 @@ load _helpers
       yq -r '.spec.template.spec.securityContext.fsGroup' | tee /dev/stderr)
   [ "${actual}" = "2000" ]
 }
+
+@test "server/dev-StatefulSet: add extraArgs" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --show-only templates/server-statefulset.yaml \
+      --set 'server.dev.enabled=true' \
+      --set 'server.extraArgs=foobar' \
+      . | tee /dev/stderr |
+       yq -r '.spec.template.spec.containers[0].args[0]' | tee /dev/stderr)
+  [[ "${actual}" = *"foobar"* ]]
+}

--- a/test/unit/server-network-policy.bats
+++ b/test/unit/server-network-policy.bats
@@ -20,3 +20,16 @@ load _helpers
       yq 'length > 0' | tee /dev/stderr)
   [ "${actual}" = "true" ]
 }
+
+@test "server/network-policy: egress enabled by server.networkPolicy.egress" {
+  cd `chart_dir`
+  local actual=$(helm template \
+      --set 'server.networkPolicy.enabled=true' \
+      --set 'server.networkPolicy.egress[0].to[0].ipBlock.cidr=10.0.0.0/24' \
+      --set 'server.networkPolicy.egress[0].ports[0].protocol=TCP' \
+      --set 'server.networkPolicy.egress[0].ports[0].port=443' \
+      --show-only templates/server-network-policy.yaml  \
+      . | tee /dev/stderr |
+      yq -r '.spec.egress[0].to[0].ipBlock.cidr' | tee /dev/stderr)
+  [ "${actual}" = "10.0.0.0/24" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -417,6 +417,9 @@ server:
   dev:
     enabled: false
 
+    # Set VAULT_DEV_ROOT_TOKEN_ID value
+    devRootToken: "root"
+
   # Run Vault in "standalone" mode. This is the default mode that will deploy if
   # no arguments are given to helm. This requires a PVC for data storage to use
   # the "file" backend.  This mode is not highly available and should not be scaled

--- a/values.yaml
+++ b/values.yaml
@@ -27,6 +27,17 @@ injector:
   # True if you want to enable vault agent injection.
   enabled: true
 
+  replicas: 1
+
+  # If multiple replicas are specified, by default a leader-elector side-car
+  # will be created so that only one injector attempts to create TLS certificates.
+  leaderElector:
+    enabled: true
+    image:
+      repository: "gcr.io/google_containers/leader-elector"
+      tag: "0.4"
+    ttl: 60s
+
   # If true, will enable a node exporter metrics endpoint at /metrics.
   metrics:
     enabled: false
@@ -112,7 +123,17 @@ injector:
   # Affinity Settings for injector pods
   # This should be a multi-line string matching the affinity section of a
   # PodSpec.
-  affinity: null
+  # Commenting out or setting as empty the affinity variable, will allow
+  # deployment of multiple replicas to single node services such as Minikube.
+  affinity: |
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              app.kubernetes.io/name: {{ template "vault.name" . }}
+              app.kubernetes.io/instance: "{{ .Release.Name }}"
+              component: injector
+          topologyKey: kubernetes.io/hostname
 
   # Toleration Settings for injector pods
   # This should be a multi-line string matching the Toleration array

--- a/values.yaml
+++ b/values.yaml
@@ -132,7 +132,7 @@ injector:
             matchLabels:
               app.kubernetes.io/name: {{ template "vault.name" . }}
               app.kubernetes.io/instance: "{{ .Release.Name }}"
-              component: injector
+              component: webhook
           topologyKey: kubernetes.io/hostname
 
   # Toleration Settings for injector pods

--- a/values.yaml
+++ b/values.yaml
@@ -134,6 +134,10 @@ injector:
   # of the annotations to apply to the injector pods
   annotations: {}
 
+  # Extra labels to attach to the agent-injector
+  # This should be a YAML map of the labels to apply to the injector
+  extraLabels: {}
+
   # Injector service specific config
   service:
     # Extra annotations to attach to the injector service

--- a/values.yaml
+++ b/values.yaml
@@ -130,7 +130,7 @@ injector:
       requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
             matchLabels:
-              app.kubernetes.io/name: {{ template "vault.name" . }}
+              app.kubernetes.io/name: {{ template "vault.name" . }}-agent-injector
               app.kubernetes.io/instance: "{{ .Release.Name }}"
               component: webhook
           topologyKey: kubernetes.io/hostname

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.7.0"
+    tag: "0.8.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -57,7 +57,7 @@ injector:
   # required.
   agentImage:
     repository: "vault"
-    tag: "1.6.1"
+    tag: "1.6.2"
 
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
@@ -171,7 +171,7 @@ server:
 
   image:
     repository: "vault"
-    tag: "1.6.1"
+    tag: "1.6.2"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 

--- a/values.yaml
+++ b/values.yaml
@@ -342,6 +342,14 @@ server:
   # Enables network policy for server pods
   networkPolicy:
     enabled: false
+    egress: []
+    # egress:
+    # - to:
+    #   - ipBlock:
+    #       cidr: 10.0.0.0/24
+    #   ports:
+    #   - protocol: TCP
+    #     port: 443
 
   # Priority class for server pods
   priorityClassName: ""

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,7 @@ injector:
   # image sets the repo and tag of the vault-k8s image to use for the injector.
   image:
     repository: "hashicorp/vault-k8s"
-    tag: "0.6.0"
+    tag: "0.7.0"
     pullPolicy: IfNotPresent
 
   # agentImage sets the repo and tag of the Vault image to use for the Vault Agent
@@ -57,7 +57,7 @@ injector:
   # required.
   agentImage:
     repository: "vault"
-    tag: "1.5.4"
+    tag: "1.6.1"
 
   # Mount Path of the Vault Kubernetes Auth Method.
   authPath: "auth/kubernetes"
@@ -171,7 +171,7 @@ server:
 
   image:
     repository: "vault"
-    tag: "1.5.4"
+    tag: "1.6.1"
     # Overrides the default Image Pull Policy
     pullPolicy: IfNotPresent
 

--- a/values.yaml
+++ b/values.yaml
@@ -134,6 +134,11 @@ injector:
   # of the annotations to apply to the injector pods
   annotations: {}
 
+  # Injector service specific config
+  service:
+    # Extra annotations to attach to the injector service
+    annotations: {}
+
 server:
   # Resource requests, limits, etc. for the server cluster placement. This
   # should map directly to the value of the resources field for a PodSpec.

--- a/values.yaml
+++ b/values.yaml
@@ -70,11 +70,12 @@ injector:
   #      sidecar-injector: enabled
   namespaceSelector: {}
 
-  # Configures failurePolicy of the webhook. By default webhook failures are ignored.
+  # Configures failurePolicy of the webhook. The "unspecified" default behaviour deoends on the
+  # API Version of the WebHook.
   # To block pod creation while webhook is unavailable, set the policy to `Fail` below.
   # See https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#failure-policy
   #
-  # failurePolcy: Fail
+  failurePolicy: Ignore
 
   certs:
     # secretName is the name of the secret that has the TLS certificate and


### PR DESCRIPTION
This PR rebases this fork to tag v0.9.1 of the upstream repository in order to allow an upgrade to 1.6.7.